### PR TITLE
Tensorflow Docker images with GPU support and CPU-optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Tensorflow Docker images compiled for CPU-optimizations and GPUs.
+Tensorflow Docker images compiled with GPU support and CPU-optimizations.

--- a/python2.7-bazel-gpu/Dockerfile
+++ b/python2.7-bazel-gpu/Dockerfile
@@ -1,0 +1,8 @@
+FROM triage/ubuntu16.04-bazel
+
+# Install Python
+RUN apt-get -y update && \
+    apt-get install -y build-essential python python-dev python-pip python-virtualenv && \
+    apt-get install -y git && \
+    python -m pip install pip --upgrade && \
+    python -m pip install wheel

--- a/python2.7-bazel-gpu/Dockerfile
+++ b/python2.7-bazel-gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM triage/ubuntu16.04-bazel
+FROM triage/ubuntu16.04-bazel-gpu
 
 # Install Python
 RUN apt-get -y update && \

--- a/python2.7-bazel/Dockerfile
+++ b/python2.7-bazel/Dockerfile
@@ -1,0 +1,8 @@
+FROM triage/ubuntu16.04-bazel
+
+# Install Python
+RUN apt-get -y update && \
+    apt-get install -y build-essential python python-dev python-pip python-virtualenv && \
+    apt-get install -y git && \
+    python -m pip install pip --upgrade && \
+    python -m pip install wheel

--- a/python2.7-tensorflow-serving-gpu/Dockerfile
+++ b/python2.7-tensorflow-serving-gpu/Dockerfile
@@ -1,0 +1,46 @@
+FROM triage/python3.6-bazel-gpu
+
+# Fix paths so that CUDNN can be found
+# See https://github.com/tensorflow/tensorflow/issues/8264
+RUN ls -lah /usr/local/cuda/lib64/*
+RUN mkdir /usr/lib/x86_64-linux-gnu/include/ && \
+  ln -s /usr/lib/x86_64-linux-gnu/include/cudnn.h /usr/lib/x86_64-linux-gnu/include/cudnn.h && \
+  ln -s /usr/include/cudnn.h /usr/local/cuda/include/cudnn.h && \
+  ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so /usr/local/cuda/lib64/libcudnn.so && \
+  ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.6 /usr/local/cuda/lib64/libcudnn.so.6
+
+# Fix from https://github.com/tensorflow/serving/issues/327#issuecomment-282207825
+WORKDIR /
+RUN git clone https://github.com/NVIDIA/nccl.git && \
+    cd nccl/ && \
+    make CUDA_HOME=/usr/local/cuda && \
+    make install && \
+    mkdir -p /usr/local/include/external/nccl_archive/src && \
+    ln -s /usr/local/include/nccl.h /usr/local/include/external/nccl_archive/src/nccl.h
+
+# Build optimized tensorflow-serving and install
+ENV TENSORFLOW_SERVING_VERSION 1.3.0
+ENV CI_BUILD_PYTHON python
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+ENV TF_NEED_CUDA 1
+ENV TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2,6.0,6.1
+RUN cd /opt && \
+    git clone --recurse-submodules https://github.com/tensorflow/serving && \
+    cd serving && \
+    git checkout tags/$TENSORFLOW_SERVING_VERSION && \
+    cd tensorflow && \
+    tensorflow/tools/ci_build/builds/configured GPU && \
+    cd .. && \
+    pip install numpy grpcio && \
+    bazel build -c opt \
+                --copt=-mavx \
+                --copt=-mavx2 \
+                --copt=-mfma \
+                --copt=-mfpmath=both \
+                --copt=-msse4.2 \
+                --copt=-msse4.1 \
+                --config=cuda \
+                --crosstool_top=@local_config_cuda//crosstool:toolchain \
+        tensorflow_serving/... && \
+    cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server /usr/local/bin/ && \
+    bazel clean --expunge

--- a/python2.7-tensorflow-serving-gpu/Dockerfile
+++ b/python2.7-tensorflow-serving-gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM triage/python3.6-bazel-gpu
+FROM triage/python2.7-bazel-gpu
 
 # Fix paths so that CUDNN can be found
 # See https://github.com/tensorflow/tensorflow/issues/8264

--- a/python2.7-tensorflow-serving/Dockerfile
+++ b/python2.7-tensorflow-serving/Dockerfile
@@ -1,0 +1,22 @@
+FROM triage/python3.6-bazel
+
+# Build optimized tensorflow-serving and install
+ENV TENSORFLOW_SERVING_VERSION 1.3.0
+RUN cd /opt && \
+    git clone --recurse-submodules https://github.com/tensorflow/serving && \
+    cd serving && \
+    git checkout tags/$TENSORFLOW_SERVING_VERSION && \
+    cd tensorflow && \
+    tensorflow/tools/ci_build/builds/configured CPU && \
+    cd .. && \
+    pip install numpy grpcio && \
+    bazel build -c opt \
+                --copt=-mavx \
+                --copt=-mavx2 \
+                --copt=-mfma \
+                --copt=-mfpmath=both \
+                --copt=-msse4.2 \
+                --copt=-msse4.1 \
+        tensorflow_serving/... && \
+    cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server /usr/local/bin/ && \
+    bazel clean --expunge

--- a/python2.7-tensorflow-serving/Dockerfile
+++ b/python2.7-tensorflow-serving/Dockerfile
@@ -1,4 +1,4 @@
-FROM triage/python3.6-bazel
+FROM triage/python2.7-bazel
 
 # Build optimized tensorflow-serving and install
 ENV TENSORFLOW_SERVING_VERSION 1.3.0

--- a/python3.6-bazel-gpu/Dockerfile
+++ b/python3.6-bazel-gpu/Dockerfile
@@ -1,0 +1,20 @@
+FROM triage/ubuntu16.04-bazel-gpu
+
+# Install Python
+RUN apt-get -y update && \
+    apt-get install -y software-properties-common vim && \
+    add-apt-repository ppa:jonathonf/python-3.6 && \
+    apt-get -y update && \
+    apt-get install -y build-essential python3.6 python3.6-dev python3-pip python3.6-venv && \
+    apt-get install -y git && \
+    python3.6 -m pip install pip --upgrade && \
+    python3.6 -m pip install wheel && \
+    cd /usr/bin && \
+    rm -f python pip idle pydoc python2-config && \
+    ln -s idle3.6 idle && \
+    ln -s pydoc3.6 pydoc && \
+    ln -s python3.6 python && \
+    ln -s python3.6-config python-config && \
+    ln -s pip3.6 pip
+
+CMD ["/bin/bash"]

--- a/python3.6-bazel/Dockerfile
+++ b/python3.6-bazel/Dockerfile
@@ -1,0 +1,20 @@
+FROM triage/ubuntu16.04-bazel
+
+# Install Python
+RUN apt-get -y update && \
+    apt-get install -y software-properties-common vim && \
+    add-apt-repository ppa:jonathonf/python-3.6 && \
+    apt-get -y update && \
+    apt-get install -y build-essential python3.6 python3.6-dev python3-pip python3.6-venv && \
+    apt-get install -y git && \
+    python3.6 -m pip install pip --upgrade && \
+    python3.6 -m pip install wheel && \
+    cd /usr/bin && \
+    rm -f python pip idle pydoc python2-config && \
+    ln -s idle3.6 idle && \
+    ln -s pydoc3.6 pydoc && \
+    ln -s python3.6 python && \
+    ln -s python3.6-config python-config && \
+    ln -s pip3.6 pip
+
+CMD ["/bin/bash"]

--- a/python3.6-tensorflow-gpu/Dockerfile
+++ b/python3.6-tensorflow-gpu/Dockerfile
@@ -1,0 +1,45 @@
+FROM triage/python3.6-bazel-gpu
+
+# Fix paths so that CUDNN can be found
+# See https://github.com/tensorflow/tensorflow/issues/8264
+RUN ls -lah /usr/local/cuda/lib64/*
+RUN mkdir /usr/lib/x86_64-linux-gnu/include/ && \
+  ln -s /usr/lib/x86_64-linux-gnu/include/cudnn.h /usr/lib/x86_64-linux-gnu/include/cudnn.h && \
+  ln -s /usr/include/cudnn.h /usr/local/cuda/include/cudnn.h && \
+  ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so /usr/local/cuda/lib64/libcudnn.so && \
+  ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.6 /usr/local/cuda/lib64/libcudnn.so.6
+
+# Fix from https://github.com/tensorflow/serving/issues/327#issuecomment-282207825
+WORKDIR /
+RUN git clone https://github.com/NVIDIA/nccl.git && \
+    cd nccl/ && \
+    make CUDA_HOME=/usr/local/cuda && \
+    make install && \
+    mkdir -p /usr/local/include/external/nccl_archive/src && \
+    ln -s /usr/local/include/nccl.h /usr/local/include/external/nccl_archive/src/nccl.h
+
+# Build optimized tensorflow and install
+ENV TENSORFLOW_VERSION v1.3.0
+ENV CI_BUILD_PYTHON python
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+ENV TF_NEED_CUDA 1
+ENV TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2,6.0,6.1
+RUN cd /opt && \
+    git clone https://github.com/tensorflow/tensorflow && \
+    cd tensorflow && \
+    git checkout tags/$TENSORFLOW_VERSION && \
+    tensorflow/tools/ci_build/builds/configured GPU && \
+    pip install numpy && \
+    bazel build -c opt --copt=-mavx \
+                       --copt=-mavx2 \
+                       --copt=-mfma \
+                       --copt=-mfpmath=both \
+                       --copt=-msse4.2 \
+                       --copt=-msse4.1 \
+                       --config=cuda \
+        //tensorflow/tools/pip_package:build_pip_package && \
+    bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg && \
+    pip install --upgrade pip && \
+    pip install --upgrade /tmp/tensorflow_pkg/tensorflow-*.whl && \
+    bazel clean --expunge && \
+    rm -Rf /opt/tensorflow

--- a/python3.6-tensorflow-gpu/README.md
+++ b/python3.6-tensorflow-gpu/README.md
@@ -1,0 +1,33 @@
+Tensorflow Docker images compiled with GPU support and CPU-optimizations.
+
+# Building and running
+
+## GPU
+
+```bash
+nvidia-docker run -rm -i --tty triage/python3.6-tensorflow:latest nvidia-smi
+nvidia-docker run -rm -i --tty triage/python3.6-tensorflow:latest python -c "from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())"
+```
+
+----
+
+Setting up Docker on a new Ubuntu 16.04 Xenial environment:
+
+```bash
+#!/usr/bin/env bash
+sudo apt-get -y install dirmngr software-properties-common apt-transport-https
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-add-repository 'deb https://apt.dockerproject.org/repo ubuntu-xenial main'
+sudo apt-get -y update
+apt-cache policy docker-engine
+sudo apt-get install -y docker-engine
+
+sudo usermod -aG docker $USER
+#sudo su - $USER
+
+# Install nvidia-docker and nvidia-docker-plugin
+wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb
+sudo dpkg -i /tmp/nvidia-docker*.deb && rm /tmp/nvidia-docker*.deb
+```
+
+Exit and start a new shell for Docker permissions.

--- a/python3.6-tensorflow/Dockerfile
+++ b/python3.6-tensorflow/Dockerfile
@@ -1,0 +1,22 @@
+FROM triage/python3.6-bazel
+
+# Build optimized tensorflow and install
+ENV TENSORFLOW_VERSION v1.3.0
+RUN cd /opt && \
+    git clone https://github.com/tensorflow/tensorflow && \
+    cd tensorflow && \
+    git checkout tags/$TENSORFLOW_VERSION && \
+    tensorflow/tools/ci_build/builds/configured CPU && \
+    pip install numpy && \
+    bazel build -c opt --copt=-mavx \
+                       --copt=-mavx2 \
+                       --copt=-mfma \
+                       --copt=-mfpmath=both \
+                       --copt=-msse4.2 \
+                       --copt=-msse4.1 \
+        //tensorflow/tools/pip_package:build_pip_package && \
+    bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg && \
+    pip install --upgrade pip && \
+    pip install --upgrade /tmp/tensorflow_pkg/tensorflow-*.whl && \
+    bazel clean --expunge && \
+    rm -Rf /opt/tensorflow

--- a/python3.6-tensorflow/README.md
+++ b/python3.6-tensorflow/README.md
@@ -1,0 +1,39 @@
+Tensorflow Docker images compiled with CPU-optimizations.
+
+# Building and running
+
+## CPU (no GPU)
+
+```bash
+docker run --rm -i --tty triage/python3.6-tensorflow:latest python -c "from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())"
+```
+
+```
+$ docker run --rm -i --tty triage/python3.6-tensorflow:latest python -c "import tensorflow; from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())"
+[name: "/cpu:0"
+device_type: "CPU"
+memory_limit: 268435456
+locality {
+}
+incarnation: 5043280336973552040
+]
+```
+
+----
+
+Setting up Docker on a new Ubuntu 16.04 Xenial environment:
+
+```bash
+#!/usr/bin/env bash
+sudo apt-get -y install dirmngr software-properties-common apt-transport-https
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-add-repository 'deb https://apt.dockerproject.org/repo ubuntu-xenial main'
+sudo apt-get -y update
+apt-cache policy docker-engine
+sudo apt-get install -y docker-engine
+
+sudo usermod -aG docker $USER
+#sudo su - $USER
+```
+
+Exit and start a new shell for Docker permissions.

--- a/ubuntu16.04-bazel-gpu/Dockerfile
+++ b/ubuntu16.04-bazel-gpu/Dockerfile
@@ -1,0 +1,28 @@
+FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
+
+# Install Java/JDK
+RUN apt-get -y update && \
+    apt-get -y install software-properties-common curl unzip && \
+    add-apt-repository -y ppa:openjdk-r/ppa && \
+    apt-get update && \
+    apt-get install -y openjdk-8-jdk openjdk-8-jre-headless && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Bazel
+ENV BAZELRC /root/.bazelrc
+ENV BAZEL_VERSION 0.4.5
+# https://github.com/bazelbuild/bazel/issues/134
+# https://github.com/bazelbuild/bazel/issues/418
+RUN echo "startup --batch" >>/root/.bazelrc && \
+    echo "build --spawn_strategy=standalone --genrule_strategy=standalone" >> /root/.bazelrc && \
+    mkdir /bazel && \
+    cd /bazel && \
+    curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+    curl -fSsL -o /bazel/LICENSE https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
+    chmod +x bazel-*.sh && \
+    ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+    cd / && \
+    rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+
+CMD ["/bin/bash"]

--- a/ubuntu16.04-bazel/Dockerfile
+++ b/ubuntu16.04-bazel/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:16.04
+
+# Install Java/JDK
+RUN apt-get -y update && \
+    apt-get -y install software-properties-common curl unzip && \
+    add-apt-repository -y ppa:openjdk-r/ppa && \
+    apt-get update && \
+    apt-get install -y openjdk-8-jdk openjdk-8-jre-headless && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Bazel
+ENV BAZELRC /root/.bazelrc
+ENV BAZEL_VERSION 0.4.5
+# https://github.com/bazelbuild/bazel/issues/134
+# https://github.com/bazelbuild/bazel/issues/418
+RUN echo "startup --batch" >>/root/.bazelrc && \
+    echo "build --spawn_strategy=standalone --genrule_strategy=standalone" >> /root/.bazelrc && \
+    mkdir /bazel && \
+    cd /bazel && \
+    curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+    curl -fSsL -o /bazel/LICENSE https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
+    chmod +x bazel-*.sh && \
+    ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+    cd / && \
+    rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Adds Docker images for:

![screen shot 2017-08-20 at 5 05 58 pm](https://user-images.githubusercontent.com/182290/29498419-ee0d44dc-85c9-11e7-836c-78080966234e.png)

We'll automate builds across versions in a different PR.

This repo replaces the `base` build in https://github.com/triagemd/tensorflow-serving-docker. The `-gs` and `-http` variants superseded by https://github.com/triagemd/tensorflow-model-serving. So `triagemd/tensorflow-serving-docker` will be deprecated.

----

CPU:
```bash
$ docker run --rm -i --tty triage/python3.6-tensorflow:latest python -c "import tensorflow; from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())"
[name: "/cpu:0"
device_type: "CPU"
memory_limit: 268435456
locality {
}
incarnation: 5043280336973552040
]
```

GPU (still building...)
```bash
```

----

A few of these are still building.