### PR TITLE
Fix tensorflow-serving GPU builds

### DIFF
--- a/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM triage/python2.7-cuda9.1
+FROM triage/python2.7-cuda9.0
 
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_gpu && \

--- a/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
@@ -1,7 +1,5 @@
-FROM triage/python2.7-cuda9.0
+FROM triage/python2.7-tensorflow-gpu
 
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_gpu && \
     chmod +x /usr/local/bin/tensorflow_model_server
-
-RUN pip install tensorflow-gpu

--- a/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
@@ -1,4 +1,4 @@
 FROM triage/python2.7-cuda9.1
 
 ARG TENSORFLOW_SERVING_VERSION
-RUN wget -O /usr/local/bin/tensorflow_model_serving https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_gpu
+RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_gpu

--- a/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
@@ -3,3 +3,5 @@ FROM triage/python2.7-cuda9.0
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_gpu && \
     chmod +x /usr/local/bin/tensorflow_model_server
+
+RUN pip install tensorflow-gpu

--- a/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile
@@ -1,4 +1,5 @@
 FROM triage/python2.7-cuda9.1
 
 ARG TENSORFLOW_SERVING_VERSION
-RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_gpu
+RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_gpu && \
+    chmod +x /usr/local/bin/tensorflow_model_server

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
@@ -1,4 +1,4 @@
 FROM triage/python2.7-cuda9.1-mkl
 
 ARG TENSORFLOW_SERVING_VERSION
-RUN wget -O /usr/local/bin/tensorflow_model_serving https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized_gpu
+RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized_gpu

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM triage/python2.7-cuda9.1-mkl
+FROM triage/python2.7-cuda9.0-mkl
 
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized_gpu && \

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
@@ -1,7 +1,5 @@
-FROM triage/python2.7-cuda9.0-mkl
+FROM triage/python2.7-tensorflow-optimized-gpu
 
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized_gpu && \
     chmod +x /usr/local/bin/tensorflow_model_server
-
-pip install tensorflow-gpu

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
@@ -3,3 +3,5 @@ FROM triage/python2.7-cuda9.0-mkl
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized_gpu && \
     chmod +x /usr/local/bin/tensorflow_model_server
+
+pip install tensorflow-gpu

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
@@ -1,4 +1,5 @@
 FROM triage/python2.7-cuda9.1-mkl
 
 ARG TENSORFLOW_SERVING_VERSION
-RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized_gpu
+RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized_gpu && \
+    chmod +x /usr/local/bin/tensorflow_model_server

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile
@@ -1,4 +1,4 @@
 FROM triage/python2.7-mkl
 
 ARG TENSORFLOW_SERVING_VERSION
-RUN wget -O /usr/local/bin/tensorflow_model_serving https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized
+RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile
@@ -1,7 +1,5 @@
-FROM triage/python2.7-mkl
+FROM triage/python2.7-tensorflow-optimized
 
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized && \
     chmod +x /usr/local/bin/tensorflow_model_server
-
-pip install tensorflow

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile
@@ -1,4 +1,5 @@
 FROM triage/python2.7-mkl
 
 ARG TENSORFLOW_SERVING_VERSION
-RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized
+RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized && \
+    chmod +x /usr/local/bin/tensorflow_model_server

--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile
@@ -3,3 +3,5 @@ FROM triage/python2.7-mkl
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized && \
     chmod +x /usr/local/bin/tensorflow_model_server
+
+pip install tensorflow


### PR DESCRIPTION
A couple issues I hit while setting up a GPU model server:

1. Rename `/usr/local/bin/tensorflow_model_serving` to the expected `/usr/local/bin/tensorflow_model_server` and make it executable — otherwise this:
```
unknown command: tensorflow_model_server --port=9000 --model_name=model --model_base_path=/model
```

2. Use CUDA 9.0 base images — Tensorflow 1.5 doesn't support CUDA 9.1 yet https://github.com/tensorflow/tensorflow/issues/15604#issuecomment-361459526 — otherwise this:
```
>>> import tensorflow
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/__init__.py", line 24, in <module>
    from tensorflow.python import *
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/__init__.py", line 49, in <module>
    from tensorflow.python import pywrap_tensorflow
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/pywrap_tensorflow.py", line 74, in <module>
    raise ImportError(msg)
ImportError: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/pywrap_tensorflow.py", line 58, in <module>
    from tensorflow.python.pywrap_tensorflow_internal import *
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py", line 28, in <module>
    _pywrap_tensorflow_internal = swig_import_helper()
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py", line 24, in swig_import_helper
    _mod = imp.load_module('_pywrap_tensorflow_internal', fp, pathname, description)
ImportError: libcublas.so.9.0: cannot open shared object file: No such file or directory


Failed to load the native TensorFlow runtime.

See https://www.tensorflow.org/install/install_sources#common_installation_problems

for some common reasons and solutions.  Include the entire stack trace
above this error message when asking for help.
```