### PR TITLE
Use CUDA 9.0 for tensorflow-gpu build

### DIFF
--- a/builders/build-tensorflow-serving-gpu.sh
+++ b/builders/build-tensorflow-serving-gpu.sh
@@ -3,7 +3,7 @@ set -e -x
 
 export CI_BUILD_PYTHON=python
 export TF_NEED_CUDA=1
-export TF_CUDA_VERSION=9.1
+export TF_CUDA_VERSION=9.0
 export TF_CUDNN_VERSION=7
 export TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2,6.0,6.1,7.0
 cd /opt

--- a/tensorflow-serving/python2.7-tensorflow-serving.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM triage/python2.7-tensorflow
 
 ARG TENSORFLOW_SERVING_VERSION
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal" | tee /etc/apt/sources.list.d/tensorflow-serving.list  && \


### PR DESCRIPTION
 - Build tensorflow-serving GPU (non optimized) with CUDA 9.0
 - Build tensorflow-serving non-gpu non-optimized with tensorflow base image too