### PR TITLE
Fixed CUDA version in GPU build images

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ When a new version of Tensorflow is released:
 | Binary | |
 |-|-|
 | **Tensorflow Serving:** |
-| tensorflow-serving-optimized | https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-1.5.0/tensorflow_model_server_optimized |
-| tensorflow-serving-gpu | https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-1.5.0/tensorflow_model_server_gpu |
-| tensorflow-serving-optimized-gpu | https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-1.5.0/tensorflow_model_server_optimized_gpu |
+| CPU optimized, with Intel MKL | https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-1.5.0/tensorflow_model_server_optimized |
+| GPU, CUDA 9.0, without CPU optimization | https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-1.5.0/tensorflow_model_server_gpu |
+| GPU, CUDA 9.1, with CPU optimization, with Intel MKL | https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-1.5.0/tensorflow_model_server_optimized_gpu |
 
 | Docker image | |
 |-|-|

--- a/builders/bazel-cpu.Dockerfile
+++ b/builders/bazel-cpu.Dockerfile
@@ -1,14 +1,10 @@
 FROM ubuntu:16.04
 
-ARG BAZEL_VERSION
 RUN apt-get -y update && \
-    apt-get -y install build-essential cmake software-properties-common curl unzip openjdk-8-jdk openjdk-8-jre-headless git python python-dev python-pip python-virtualenv && \
-    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
-    curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
-    apt-get -y update && \
-    apt-get -y install bazel=$BAZEL_VERSION && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get -y install build-essential cmake software-properties-common curl wget unzip pkg-config zip zlib1g-dev openjdk-8-jdk openjdk-8-jre-headless git python python-dev python-pip python-virtualenv && \
+    wget https://github.com/bazelbuild/bazel/releases/download/0.9.0/bazel-0.9.0-installer-linux-x86_64.sh && \
+    chmod +x bazel-0.9.0-installer-linux-x86_64.sh && \
+    ./bazel-0.9.0-installer-linux-x86_64.sh
 
 # Install MKL-DNN
 RUN cd /tmp && \

--- a/builders/bazel-gpu.Dockerfile
+++ b/builders/bazel-gpu.Dockerfile
@@ -1,15 +1,11 @@
 ARG CUDA_VERSION
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn7-devel-ubuntu16.04
 
-ARG BAZEL_VERSION
 RUN apt-get -y update && \
-    apt-get -y install build-essential software-properties-common curl unzip openjdk-8-jdk openjdk-8-jre-headless git python python-dev python-pip python-virtualenv && \
-    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
-    curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
-    apt-get -y update && \
-    apt-get -y install bazel=$BAZEL_VERSION && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get -y install build-essential software-properties-common curl unzip wget pkg-config zip zlib1g-dev openjdk-8-jdk openjdk-8-jre-headless git python python-dev python-pip python-virtualenv && \
+    wget https://github.com/bazelbuild/bazel/releases/download/0.9.0/bazel-0.9.0-installer-linux-x86_64.sh && \
+    chmod +x bazel-0.9.0-installer-linux-x86_64.sh && \
+    ./bazel-0.9.0-installer-linux-x86_64.sh
 
 ENV LD_LIBRARY_PATH /usr/local/lib:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 

--- a/builders/bazel-gpu.Dockerfile
+++ b/builders/bazel-gpu.Dockerfile
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04
+ARG CUDA_VERSION
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn7-devel-ubuntu16.04
 
 ARG BAZEL_VERSION
 RUN apt-get -y update && \

--- a/script/distribute-binaries
+++ b/script/distribute-binaries
@@ -7,7 +7,8 @@ set -x
 
 # build base images
 docker build -t bazel-cpu --build-arg BAZEL_VERSION=$BAZEL_VERSION -f builders/bazel-cpu.Dockerfile .
-docker build -t bazel-gpu --build-arg BAZEL_VERSION=$BAZEL_VERSION -f builders/bazel-gpu.Dockerfile .
+docker build -t bazel-gpu-cuda9.0 --build-arg BAZEL_VERSION=$BAZEL_VERSION --build-arg CUDA_VERSION=9.0 -f builders/bazel-gpu.Dockerfile .
+docker build -t bazel-gpu-cuda9.1 --build-arg BAZEL_VERSION=$BAZEL_VERSION --build-arg CUDA_VERSION=9.1 -f builders/bazel-gpu.Dockerfile .
 
 # fetch releases tool and make the release
 wget -qO- https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 | tar xvj -C /tmp --strip-components 3 bin/linux/amd64/github-release
@@ -27,7 +28,7 @@ docker run --rm -v $(pwd)/builders/build-tensorflow-serving-optimized.sh:/build.
 # tf-serving-gpu
 docker run --rm -v $(pwd)/builders/build-tensorflow-serving-gpu.sh:/build.sh -v $(pwd)/builds:/builds \
            -e TENSORFLOW_VERSION=$TENSORFLOW_VERSION -e TENSORFLOW_SERVING_VERSION=$TENSORFLOW_SERVING_VERSION \
-           bazel-gpu bash /build.sh
+           bazel-gpu-cuda9.0 bash /build.sh
 /tmp/github-release upload --user triagemd --repo tensorflow-builds \
                            --tag tf-serving-$TENSORFLOW_SERVING_VERSION \
                            --name tensorflow_model_server_gpu --file builds/tensorflow_model_server_gpu
@@ -35,7 +36,7 @@ docker run --rm -v $(pwd)/builders/build-tensorflow-serving-gpu.sh:/build.sh -v 
 # tf-serving-optimized-gpu
 docker run --rm -v $(pwd)/builders/build-tensorflow-serving-optimized-gpu.sh:/build.sh -v $(pwd)/builds:/builds \
            -e TENSORFLOW_VERSION=$TENSORFLOW_VERSION -e TENSORFLOW_SERVING_VERSION=$TENSORFLOW_SERVING_VERSION \
-           bazel-gpu bash /build.sh
+           bazel-gpu-cuda9.1 bash /build.sh
 /tmp/github-release upload --user triagemd --repo tensorflow-builds \
                            --tag tf-serving-$TENSORFLOW_SERVING_VERSION \
                            --name tensorflow_model_server_optimized_gpu --file builds/tensorflow_model_server_optimized_gpu

--- a/script/distribute-binaries
+++ b/script/distribute-binaries
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 set -e
-BAZEL_VERSION=0.9.0
 TENSORFLOW_VERSION=1.5.0
 TENSORFLOW_SERVING_VERSION=1.5.0
 set -x
 
 # build base images
-docker build -t bazel-cpu --build-arg BAZEL_VERSION=$BAZEL_VERSION -f builders/bazel-cpu.Dockerfile .
-docker build -t bazel-gpu-cuda9.0 --build-arg BAZEL_VERSION=$BAZEL_VERSION --build-arg CUDA_VERSION=9.0 -f builders/bazel-gpu.Dockerfile .
-docker build -t bazel-gpu-cuda9.1 --build-arg BAZEL_VERSION=$BAZEL_VERSION --build-arg CUDA_VERSION=9.1 -f builders/bazel-gpu.Dockerfile .
+docker build -t bazel-cpu -f builders/bazel-cpu.Dockerfile .
+docker build -t bazel-gpu-cuda9.0 --build-arg CUDA_VERSION=9.0 -f builders/bazel-gpu.Dockerfile .
+docker build -t bazel-gpu-cuda9.1 --build-arg CUDA_VERSION=9.1 -f builders/bazel-gpu.Dockerfile .
 
 # fetch releases tool and make the release
 wget -qO- https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 | tar xvj -C /tmp --strip-components 3 bin/linux/amd64/github-release


### PR DESCRIPTION
The builder images only had CUDA 9.1 installed

I'll get an updated tensorflow-serving-gpu binary out shortly, build takes maybe 30 mins.