### PR TITLE
Add missing libraries for optimized-gpu

### DIFF
--- a/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
+++ b/tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile
@@ -1,5 +1,9 @@
 FROM triage/python2.7-tensorflow-optimized-gpu
 
+RUN apt-get -y update && \
+    apt-get install -y libgomp1 && \
+    apt-get clean
+
 ARG TENSORFLOW_SERVING_VERSION
 RUN wget -O /usr/local/bin/tensorflow_model_server https://github.com/triagemd/tensorflow-builds/releases/download/tf-serving-$TENSORFLOW_SERVING_VERSION/tensorflow_model_server_optimized_gpu && \
     chmod +x /usr/local/bin/tensorflow_model_server


### PR DESCRIPTION
This makes `model-serving-optimized-gpu` actually work (tested on the DGX).

However it still won't work on GKE -- CUDA 9.1 requires at least driver 387.26 (https://github.com/NVIDIA/nvidia-docker/wiki/CUDA#requirements) but the GKE installer puts 384.111 (https://github.com/GoogleCloudPlatform/cos-gpu-installer/blob/master/install-test-gpu.cfg#L21).
Should be fixed with https://github.com/GoogleCloudPlatform/cos-gpu-installer/pull/6.
