### PR TITLE
Switch non-optimized TF-serving image to 1.6

### DIFF
--- a/script/distribute-docker-tensorflow-serving
+++ b/script/distribute-docker-tensorflow-serving
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -e
 source script/docker_build_and_push.sh
-TENSORFLOW_SERVING_VERSION=1.5.0
+GOOGLE_TENSORFLOW_SERVING_VERSION=1.6.0
+BINARIES_TENSORFLOW_SERVING_VERSION=1.5.0
 set -x
 
-docker_build_and_push triage/python2.7-tensorflow-serving:$TENSORFLOW_SERVING_VERSION tensorflow-serving/python2.7-tensorflow-serving.Dockerfile "--build-arg TENSORFLOW_SERVING_VERSION=$TENSORFLOW_SERVING_VERSION"
-docker_build_and_push triage/python2.7-tensorflow-serving-optimized:$TENSORFLOW_SERVING_VERSION tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile "--build-arg TENSORFLOW_SERVING_VERSION=$TENSORFLOW_SERVING_VERSION"
+docker_build_and_push triage/python2.7-tensorflow-serving:$GOOGLE_TENSORFLOW_SERVING_VERSION tensorflow-serving/python2.7-tensorflow-serving.Dockerfile "--build-arg TENSORFLOW_SERVING_VERSION=$GOOGLE_TENSORFLOW_SERVING_VERSION"
+docker_build_and_push triage/python2.7-tensorflow-serving-optimized:$BINARIES_TENSORFLOW_SERVING_VERSION tensorflow-serving/python2.7-tensorflow-serving-optimized.Dockerfile "--build-arg TENSORFLOW_SERVING_VERSION=$BINARIES_TENSORFLOW_SERVING_VERSION"
 
-docker_build_and_push triage/python2.7-tensorflow-serving-gpu:$TENSORFLOW_SERVING_VERSION tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile "--build-arg TENSORFLOW_SERVING_VERSION=$TENSORFLOW_SERVING_VERSION"
-docker_build_and_push triage/python2.7-tensorflow-serving-optimized-gpu:$TENSORFLOW_SERVING_VERSION tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile "--build-arg TENSORFLOW_SERVING_VERSION=$TENSORFLOW_SERVING_VERSION"
+docker_build_and_push triage/python2.7-tensorflow-serving-gpu:$BINARIES_TENSORFLOW_SERVING_VERSION tensorflow-serving/python2.7-tensorflow-serving-gpu.Dockerfile "--build-arg TENSORFLOW_SERVING_VERSION=$BINARIES_TENSORFLOW_SERVING_VERSION"
+docker_build_and_push triage/python2.7-tensorflow-serving-optimized-gpu:$BINARIES_TENSORFLOW_SERVING_VERSION tensorflow-serving/python2.7-tensorflow-serving-optimized-gpu.Dockerfile "--build-arg TENSORFLOW_SERVING_VERSION=$BINARIES_TENSORFLOW_SERVING_VERSION"


### PR DESCRIPTION
Google has:
- released TF-serving 1.6 (:tada:)
- not open-sourced it yet: https://github.com/tensorflow/serving/releases (:unamused:)
- removed 1.5 from their APT repo, making builds fail (:rage:)  