### PR TITLE
Switch image base to Debian stretch

### DIFF
--- a/tensorflow/python2.7-tensorflow.Dockerfile
+++ b/tensorflow/python2.7-tensorflow.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-stretch
 
 ARG TENSORFLOW_VERSION
 RUN pip install --no-cache-dir tensorflow==$TENSORFLOW_VERSION

--- a/tensorflow/python3.6-tensorflow.Dockerfile
+++ b/tensorflow/python3.6-tensorflow.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-stretch
 
 ARG TENSORFLOW_VERSION
 RUN pip install --no-cache-dir tensorflow==$TENSORFLOW_VERSION


### PR DESCRIPTION
It seems Google, in their infinite wisdom, has decided nobody uses Linux distros more than 4 months old :rage: 

If I ever work there and a coworker suggests dropping support for *one of the 10 most popular Docker images*, I will hit them over the head.

(\</rant>)